### PR TITLE
Update README related to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Shun Sakai <sorairolake@protonmail.ch>"]
 edition = "2018"
 description = "A data-serialization format converter"
-readme = "README.adoc"
 repository = "https://github.com/sorairolake/dsconv"
 license = "Apache-2.0"
 categories = ["command-line-utilities"]

--- a/README.adoc
+++ b/README.adoc
@@ -11,6 +11,17 @@ toc::[]
 
 == Installation
 
+=== Via a package manager
+
+|===
+|OS |Method |Package |Command
+
+|Any
+|Cargo
+|https://crates.io/crates/dsconv[`dsconv`]
+|`cargo install dsconv`
+|===
+
 === How to build and install
 
 Please see the link:BUILD.adoc[Build Guide].

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,9 @@
 = dsconv
 :toc: macro
 
-image::https://github.com/sorairolake/dsconv/workflows/CI/badge.svg[CI, link=https://github.com/sorairolake/dsconv/actions?query=workflow%3ACI]
+image:https://github.com/sorairolake/dsconv/workflows/CI/badge.svg[CI, link=https://github.com/sorairolake/dsconv/actions?query=workflow%3ACI]
+image:https://img.shields.io/crates/v/dsconv[Version, link=https://crates.io/crates/dsconv]
+image:https://img.shields.io/crates/l/dsconv[License, link=https://apache.org/licenses/LICENSE-2.0]
 
 *dsconv* is a command-line utility for converting from one data-serialization format to another.
 


### PR DESCRIPTION
Remove the `readme` field from `Cargo.toml` because crates.io doesn't support rendering AsciiDoc.